### PR TITLE
Update index.html

### DIFF
--- a/custom-elements/public/index.html
+++ b/custom-elements/public/index.html
@@ -10,9 +10,16 @@
 	<link rel='stylesheet' href='/global.css'>
 	<link rel='stylesheet' href='/build/bundle.css'>
 
-	<script defer src='/build/bundle.js'></script>
+	<script type="module">
+		import { Greet, Counter } from '/build/bundle.js';
+
+		customElements.define('my-greet', Greet);
+		customElements.define('my-counter', Counter);
+	</script>
 </head>
 
 <body>
+	<my-greet></my-greet>
+	<my-counter></my-counter>
 </body>
 </html>


### PR DESCRIPTION
`bundle.js` is a *module*, not a script, so you need to use `<script type="module">`. Since you want to *do something* with the exports, it's not enough to use the `src` attribute — you need to `import` the classes and register them.